### PR TITLE
Add AIMLAPI image generation node

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It allows you to interact with large language models (LLMs) and multimodal model
 ## Features
 
 - Chat with any LLM available on AI/ML API
+- Generate images with OpenAI DALL·E, Flux, and other providers
 - Dynamic model selection
 - Parameter tuning (temperature, max tokens, top-p, penalties)
 - Multiple output formats: raw, full response, messages, or plain text
@@ -54,7 +55,7 @@ To use this node, you must configure **AI/ML API** credentials:
 
 📚 You can also refer to the [provider documentation](https://docs.aimlapi.com/?utm_source=n8n&utm_medium=github&utm_campaign=integration) for detailed API specs.
 
-### Node Parameters
+### Chat Completion Node Parameters
 
 * **Model**: Select model from the list (e.g. `gpt-3.5-turbo`)
 * **Prompt**: User prompt to send to the model
@@ -73,6 +74,26 @@ To use this node, you must configure **AI/ML API** credentials:
   * **Frequency Penalty**
   * **Response Format** (e.g. `text`)
 
+### Image Generation Node Parameters
+
+* **Model**: Pick an image model such as `dall-e-3` or `flux-dev`
+* **Prompt**: Textual instructions describing the desired image
+* **Extract From Response**:
+
+  * `Generated Images` – one item per generated image containing URL/base64
+  * `First Image Only` – pick only the first generated image
+  * `Image URLs Array` – return all URLs in a single array
+  * `Base64 Array` – return base64 payloads in a single array
+  * `Full Raw JSON` – return the API response without processing
+* **Options**:
+
+  * **Image Count** – number of images to generate
+  * **Size** – choose target resolution
+  * **Quality** – `standard` or `high`
+  * **Style** – `natural` or `vivid`
+  * **Background** – `default` or `transparent`
+  * **Response Format** – `url` or `b64_json`
+
 ---
 
 ## Usage Example
@@ -84,6 +105,13 @@ To use this node, you must configure **AI/ML API** credentials:
 5. Enter prompt: `What is the capital of France?`
 6. Select `Extract: Text Only`
 7. Execute — you’ll get `Paris`
+
+For image generation:
+
+1. Add the **AI/ML Image Generation** node
+2. Select an image model (e.g. `dall-e-3`)
+3. Provide a visual prompt such as `A watercolor landscape of mountains at sunset`
+4. Run the workflow and retrieve the generated image URL or base64 payload
 
 ---
 

--- a/nodes/AIMLAPI/AimlApi.node.ts
+++ b/nodes/AIMLAPI/AimlApi.node.ts
@@ -1,14 +1,13 @@
 import {
-	IExecuteSingleFunctions,
-	IHttpRequestOptions,
-	ILoadOptionsFunctions,
-	IN8nHttpFullResponse,
-	INodeExecutionData,
-	INodePropertyOptions,
-	INodeType,
-	INodeTypeDescription,
+        IExecuteSingleFunctions,
+        ILoadOptionsFunctions,
+        IN8nHttpFullResponse,
+        INodeExecutionData,
+        INodeType,
+        INodeTypeDescription,
 } from 'n8n-workflow';
 import {NodeConnectionType} from 'n8n-workflow/dist/Interfaces';
+import {fetchModelsByType} from './shared';
 
 export class AimlApi implements INodeType {
 	description: INodeTypeDescription = {
@@ -41,9 +40,9 @@ export class AimlApi implements INodeType {
 				displayName: 'Model Name or ID',
 				name: 'model',
 				type: 'options',
-				typeOptions: {
-					loadOptionsMethod: 'getModels',
-				},
+                                typeOptions: {
+                                        loadOptionsMethod: 'getChatModels',
+                                },
 				default: '',
 				required: true,
 				description: 'Choose model or specify an ID using an expression. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
@@ -228,34 +227,9 @@ export class AimlApi implements INodeType {
 
 	methods = {
 		loadOptions: {
-			async getModels(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-				const credentials = await this.getCredentials('aimlApi');
-				const apiUrl = credentials.url as string;
-				const endpoint = apiUrl.endsWith('/')
-					? `${apiUrl}models`
-					: `${apiUrl}/models`;
-
-				const options: IHttpRequestOptions = {
-					method: 'GET',
-					url: endpoint,
-					json: true,
-				};
-
-				const response = await this.helpers.httpRequestWithAuthentication.call(
-					this,
-					'aimlApi',
-					options
-				);
-
-				const models = response?.models ?? response?.data ?? response;
-
-				return (models as any[])
-					.filter((model) => model.type === 'chat-completion')
-					.map((model) => ({
-						name: model.info?.name || model.name || model.id,
-						value: model.id,
-					}));
-			},
-		},
-	};
+                        async getChatModels(this: ILoadOptionsFunctions) {
+                                return fetchModelsByType.call(this, ['chat-completion']);
+                        },
+                },
+        };
 }

--- a/nodes/AIMLAPI/AimlApiImage.node.json
+++ b/nodes/AIMLAPI/AimlApiImage.node.json
@@ -1,0 +1,18 @@
+{
+        "node": "n8n-nodes-base.AimlApiImage",
+        "nodeVersion": "1.0",
+        "codexVersion": "1.0",
+        "categories": ["Utility"],
+        "resources": {
+                "credentialDocumentation": [
+                        {
+                                "url": "https://docs.n8n.io/integrations/builtin/credentials/aimlapi/"
+                        }
+                ],
+                "primaryDocumentation": [
+                        {
+                                "url": "https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-aimlapi.aimlapiimage/"
+                        }
+                ]
+        }
+}

--- a/nodes/AIMLAPI/AimlApiImage.node.ts
+++ b/nodes/AIMLAPI/AimlApiImage.node.ts
@@ -1,0 +1,337 @@
+import {
+        IExecuteSingleFunctions,
+        ILoadOptionsFunctions,
+        IN8nHttpFullResponse,
+        INodeExecutionData,
+        INodeType,
+        INodeTypeDescription,
+} from 'n8n-workflow';
+import {NodeConnectionType} from 'n8n-workflow/dist/Interfaces';
+import {fetchModelsByType} from './shared';
+
+export class AimlApiImage implements INodeType {
+        description: INodeTypeDescription = {
+                displayName: 'AI/ML Image Generation',
+                name: 'aimlApiImage',
+                icon: 'file:aimlapi.svg',
+                group: ['transform'],
+                version: 1,
+                description: 'Generate images with 300+ AI models such as DALL·E and Flux',
+                defaults: {
+                        name: 'AI/ML Image Generation',
+                },
+                inputs: [NodeConnectionType.Main],
+                outputs: [NodeConnectionType.Main],
+                credentials: [
+                        {
+                                name: 'aimlApi',
+                                required: true,
+                        },
+                ],
+                requestDefaults: {
+                        baseURL: '={{ $credentials.url.endsWith("/") ? $credentials.url.slice(0, -1) : $credentials.url }}',
+                        headers: {
+                                'Content-Type': 'application/json',
+                                'X-Title': `n8n AIMLAPI Node`,
+                        },
+                },
+                properties: [
+                        {
+                                displayName: 'Model Name or ID',
+                                name: 'model',
+                                type: 'options',
+                                typeOptions: {
+                                        loadOptionsMethod: 'getImageModels',
+                                },
+                                default: '',
+                                required: true,
+                                description:
+                                        'Choose model or specify an ID using an expression. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+                        },
+                        {
+                                displayName: 'Prompt',
+                                name: 'prompt',
+                                type: 'string',
+                                typeOptions: {
+                                        rows: 4,
+                                },
+                                default: '',
+                                required: true,
+                                description: 'Prompt to send to the AI model',
+                                routing: {
+                                        request: {
+                                                method: 'POST',
+                                                url: '/images/generations',
+                                                body: {
+                                                        model: '={{ $parameter["model"] }}',
+                                                        prompt: '={{ $value }}',
+                                                        n: '={{ $parameter["options"]["imageCount"] ?? undefined }}',
+                                                        size: '={{ $parameter["options"]["size"] ?? undefined }}',
+                                                        quality: '={{ $parameter["options"]["quality"] ?? undefined }}',
+                                                        style: '={{ $parameter["options"]["style"] ?? undefined }}',
+                                                        background:
+                                                                '={{ $parameter["options"]["background"] && $parameter["options"]["background"] !== "default" ? $parameter["options"]["background"] : undefined }}',
+                                                        response_format:
+                                                                '={{ $parameter["options"]["responseFormat"] ?? undefined }}',
+                                                        user: '={{ $parameter["options"]["user"] ?? undefined }}',
+                                                },
+                                        },
+                                        output: {
+                                                postReceive: [
+                                                        async function (
+                                                                this: IExecuteSingleFunctions,
+                                                                items: INodeExecutionData[],
+                                                                response: IN8nHttpFullResponse
+                                                        ): Promise<INodeExecutionData[]> {
+                                                                const extract = this.getNodeParameter('extract', 0) as string;
+
+                                                                const body = response.body as {
+                                                                        data?: Array<{
+                                                                                url?: string;
+                                                                                b64_json?: string;
+                                                                                revised_prompt?: string;
+                                                                        }>;
+                                                                        [key: string]: any;
+                                                                };
+
+                                                                const data = Array.isArray(body?.data) ? body.data : [];
+
+                                                                const toImageItem = (
+                                                                        image: {
+                                                                                url?: string;
+                                                                                b64_json?: string;
+                                                                                revised_prompt?: string;
+                                                                        } | undefined,
+                                                                        index: number
+                                                                ) => {
+                                                                        const item: Record<string, any> = {index};
+                                                                        if (image?.url) {
+                                                                                item.url = image.url;
+                                                                        }
+                                                                        if (image?.b64_json) {
+                                                                                item.base64 = image.b64_json;
+                                                                        }
+                                                                        if (image?.revised_prompt) {
+                                                                                item.revisedPrompt = image.revised_prompt;
+                                                                        }
+                                                                        return item;
+                                                                };
+
+                                                                if (!data.length) {
+                                                                        return this.helpers.returnJsonArray([{result: body}]);
+                                                                }
+
+                                                                if (extract === 'images') {
+                                                                        return this.helpers.returnJsonArray(
+                                                                                data.map((image, index) => toImageItem(image, index))
+                                                                        );
+                                                                }
+
+                                                                if (extract === 'first') {
+                                                                        return this.helpers.returnJsonArray([
+                                                                                toImageItem(data[0], 0),
+                                                                        ]);
+                                                                }
+
+                                                                if (extract === 'urls') {
+                                                                        return this.helpers.returnJsonArray([
+                                                                                {
+                                                                                        urls: data
+                                                                                                .map((image) => image.url)
+                                                                                                .filter((url): url is string => Boolean(url)),
+                                                                                        revisedPrompts: data
+                                                                                                .map((image) => image.revised_prompt)
+                                                                                                .filter(
+                                                                                                        (prompt): prompt is string =>
+                                                                                                                Boolean(prompt)
+                                                                                                ),
+                                                                                },
+                                                                        ]);
+                                                                }
+
+                                                                if (extract === 'base64') {
+                                                                        return this.helpers.returnJsonArray([
+                                                                                {
+                                                                                        base64: data
+                                                                                                .map((image) => image.b64_json)
+                                                                                                .filter((entry): entry is string => Boolean(entry)),
+                                                                                        revisedPrompts: data
+                                                                                                .map((image) => image.revised_prompt)
+                                                                                                .filter(
+                                                                                                        (prompt): prompt is string =>
+                                                                                                                Boolean(prompt)
+                                                                                                ),
+                                                                                },
+                                                                        ]);
+                                                                }
+
+                                                                return this.helpers.returnJsonArray([{result: body}]);
+                                                        },
+                                                ],
+                                        },
+                                },
+                        },
+                        {
+                                displayName: 'Extract From Response',
+                                name: 'extract',
+                                type: 'options',
+                                default: 'images',
+                                description: 'Choose what part of the response to return',
+                                options: [
+                                        {
+                                                name: 'Base64 Array',
+                                                value: 'base64',
+                                        },
+                                        {
+                                                name: 'First Image Only',
+                                                value: 'first',
+                                        },
+                                        {
+                                                name: 'Full Raw JSON',
+                                                value: 'raw',
+                                        },
+                                        {
+                                                name: 'Generated Images (One Item Per Image)',
+                                                value: 'images',
+                                        },
+                                        {
+                                                name: 'Image URLs Array',
+                                                value: 'urls',
+                                        },
+                                ],
+                        },
+                        {
+                                displayName: 'Options',
+                                name: 'options',
+                                type: 'collection',
+                                placeholder: 'Add Option',
+                                default: {},
+                                description: 'Additional parameters for the request',
+                                options: [
+                                        {
+                                                displayName: 'Background',
+                                                name: 'background',
+                                                type: 'options',
+                                                options: [
+                                                        {
+                                                                name: 'Default',
+                                                                value: 'default',
+                                                        },
+                                                        {
+                                                                name: 'Transparent',
+                                                                value: 'transparent',
+                                                        },
+                                                ],
+                                                default: 'default',
+                                        },
+                                        {
+                                                displayName: 'Image Count',
+                                                name: 'imageCount',
+                                                type: 'number',
+                                                typeOptions: {
+                                                        minValue: 1,
+                                                        maxValue: 10,
+                                                },
+                                                default: 1,
+                                                description: 'How many images to generate',
+                                        },
+                                        {
+                                                displayName: 'Quality',
+                                                name: 'quality',
+                                                type: 'options',
+                                                options: [
+                                                        {
+                                                                name: 'Standard',
+                                                                value: 'standard',
+                                                        },
+                                                        {
+                                                                name: 'High',
+                                                                value: 'high',
+                                                        },
+                                                ],
+                                                default: 'standard',
+                                        },
+                                        {
+                                                displayName: 'Response Format',
+                                                name: 'responseFormat',
+                                                type: 'options',
+                                                options: [
+                                                        {
+                                                                name: 'URL',
+                                                                value: 'url',
+                                                        },
+                                                        {
+                                                                name: 'Base64 JSON',
+                                                                value: 'b64_json',
+                                                        },
+                                                ],
+                                                default: 'url',
+                                        },
+                                        {
+                                                displayName: 'Size',
+                                                name: 'size',
+                                                type: 'options',
+                                                options: [
+                                                        {
+                                                                name: '1024x1024',
+                                                                value: '1024x1024',
+                                                        },
+                                                        {
+                                                                name: '1024x576',
+                                                                value: '1024x576',
+                                                        },
+                                                        {
+                                                                name: '1152x1152',
+                                                                value: '1152x1152',
+                                                        },
+                                                        {
+                                                                name: '1365x768',
+                                                                value: '1365x768',
+                                                        },
+                                                        {
+                                                                name: '512x512',
+                                                                value: '512x512',
+                                                        },
+                                                        {
+                                                                name: '896x1152',
+                                                                value: '896x1152',
+                                                        },
+                                                ],
+                                                default: '1024x1024',
+                                        },
+                                        {
+                                                displayName: 'Style',
+                                                name: 'style',
+                                                type: 'options',
+                                                options: [
+                                                        {
+                                                                name: 'Natural',
+                                                                value: 'natural',
+                                                        },
+                                                        {
+                                                                name: 'Vivid',
+                                                                value: 'vivid',
+                                                        },
+                                                ],
+                                                default: 'natural',
+                                        },
+                                        {
+                                                displayName: 'User Identifier',
+                                                name: 'user',
+                                                type: 'string',
+                                                default: '',
+                                                description: 'A unique identifier for the end-user',
+                                        },
+                                ],
+                        },
+                ],
+        };
+
+        methods = {
+                loadOptions: {
+                        async getImageModels(this: ILoadOptionsFunctions) {
+                                return fetchModelsByType.call(this, ['image', 'image-generation']);
+                        },
+                },
+        };
+}

--- a/nodes/AIMLAPI/shared.ts
+++ b/nodes/AIMLAPI/shared.ts
@@ -1,0 +1,43 @@
+import type {
+        IHttpRequestOptions,
+        ILoadOptionsFunctions,
+        INodePropertyOptions,
+} from 'n8n-workflow';
+
+export async function fetchModelsByType(
+        this: ILoadOptionsFunctions,
+        allowedTypes: string[]
+): Promise<INodePropertyOptions[]> {
+        const credentials = await this.getCredentials('aimlApi');
+        const apiUrl = credentials.url as string;
+        const endpoint = apiUrl.endsWith('/') ? `${apiUrl}models` : `${apiUrl}/models`;
+
+        const options: IHttpRequestOptions = {
+                method: 'GET',
+                url: endpoint,
+                json: true,
+        };
+
+        const response = await this.helpers.httpRequestWithAuthentication.call(
+                this,
+                'aimlApi',
+                options
+        );
+
+        const models = (response?.models ?? response?.data ?? response) as Array<Record<string, any>>;
+
+        return models
+                .filter((model) => {
+                        const type = (model.type ?? model.info?.type ?? '').toString().toLowerCase();
+                        if (!allowedTypes.length) {
+                                return true;
+                        }
+
+                        return allowedTypes.some((allowedType) => type === allowedType.toLowerCase());
+                })
+                .map((model) => ({
+                        name: model.info?.name || model.name || model.id,
+                        value: model.id,
+                        description: model.info?.description ?? model.description,
+                }));
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
       "dist/credentials/AIMLApi.credentials.js"
     ],
     "nodes": [
-      "dist/nodes/AIMLAPI/AimlApi.node.js"
+      "dist/nodes/AIMLAPI/AimlApi.node.js",
+      "dist/nodes/AIMLAPI/AimlApiImage.node.js"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add a shared helper to fetch AIMLAPI models by type for reuse across nodes
- introduce an AI/ML Image Generation node with configurable prompt, options, and extract modes
- document the new node and register it with the package manifest

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de67e50cb48329877492fb0f2a5163