### PR TITLE
feat: allow structured messages in chat completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To use this node, you must configure **AI/ML API** credentials:
 #### Chat Completion
 
 - **Use Message List** – Switch between a single prompt and a structured list of chat messages.
-- **Prompt/Messages** – Provide either one prompt or multiple messages. Each structured message defines a **Role** (`assistant`, `system`, or `user`) or a custom value such as `tool`, plus the text **Content**. When using the `tool` role, fill in the required **Tool Call ID** with the identifier returned alongside the assistant tool invocation so the API can pair the response correctly.
+- **Prompt/Messages** – Provide either one prompt or multiple messages. Each structured message selects a **Role** (`assistant`, `system`, or `user`) from the dropdown, or choose **Custom…** to enter another role such as `tool`, plus the text **Content**. When using the `tool` role, fill in the required **Tool Call ID** with the identifier returned alongside the assistant tool invocation so the API can pair the response correctly.
 - **Extract From Response** – Decide what to return (`Text Only`, `Assistant Messages`, `Choices Array`, or `Full Raw JSON`).
 - **Options** – Fine-tune completions with **Temperature**, **Top P**, **Max Tokens**, **Presence Penalty**, **Frequency Penalty**, and **Response Format**.
 

--- a/nodes/AIMLAPI/operations/chatCompletion.description.ts
+++ b/nodes/AIMLAPI/operations/chatCompletion.description.ts
@@ -55,11 +55,42 @@ export const chatCompletionProperties: INodeProperties[] = [
                                         {
                                                 displayName: 'Role',
                                                 name: 'role',
-                                                type: 'string',
-                                                default: 'user',
-                                                placeholder: 'assistant, system, user, tool, …',
+                                                type: 'options',
+                                                default: 'assistant',
+                                                options: [
+                                                        {
+                                                                name: 'Assistant',
+                                                                value: 'assistant',
+                                                        },
+                                                        {
+                                                                name: 'System',
+                                                                value: 'system',
+                                                        },
+                                                        {
+                                                                name: 'User',
+                                                                value: 'user',
+                                                        },
+                                                        {
+                                                                name: 'Custom…',
+                                                                value: 'custom',
+                                                        },
+                                                ],
                                                 description:
-                                                        'Role that the message should have in the conversation. Use "assistant", "system", or "user" for the built-in roles, or enter a custom value such as "tool" when your model expects it.',
+                                                        'Select the role for this message; choose Custom to provide a different role name such as "tool" when required by your model',
+                                        },
+                                        {
+                                                displayName: 'Custom Role',
+                                                name: 'customRole',
+                                                type: 'string',
+                                                default: '',
+                                                placeholder: 'tool',
+                                                description:
+                                                        'Enter the role name when Custom is selected (for example "tool" or any model-specific role)',
+                                                displayOptions: {
+                                                        show: {
+                                                                role: ['custom'],
+                                                        },
+                                                },
                                         },
                                         {
                                                 displayName: 'Tool Call ID',
@@ -71,7 +102,7 @@ export const chatCompletionProperties: INodeProperties[] = [
                                                         'When the role is Tool, provide the tool call identifier returned by the assistant',
                                                 displayOptions: {
                                                         show: {
-                                                                role: ['tool'],
+                                                                role: ['custom', 'tool'],
                                                         },
                                                 },
                                         },

--- a/nodes/AIMLAPI/operations/chatCompletion.execute.ts
+++ b/nodes/AIMLAPI/operations/chatCompletion.execute.ts
@@ -93,8 +93,21 @@ export async function executeChatCompletion({
                 const structuredMessages = (messagesUi.message as IDataObject[]) ?? [];
 
                 for (const entry of structuredMessages) {
-                        const rawRole = typeof entry.role === 'string' ? entry.role.trim() : '';
-                        const role = rawRole !== '' ? rawRole : 'user';
+                        const rawRoleSelection = typeof entry.role === 'string' ? entry.role.trim() : '';
+                        const normalizedSelection = rawRoleSelection.toLowerCase();
+
+                        let role: string;
+
+                        if (normalizedSelection === 'custom') {
+                                const customRoleRaw =
+                                        typeof entry.customRole === 'string' ? entry.customRole.trim() : '';
+                                role = customRoleRaw !== '' ? customRoleRaw : 'user';
+                        } else if (rawRoleSelection !== '') {
+                                role = rawRoleSelection;
+                        } else {
+                                role = 'user';
+                        }
+
                         const normalizedRole = role.toLowerCase();
                         const rawContent = typeof entry.content === 'string' ? entry.content : '';
                         const content = rawContent.trim();


### PR DESCRIPTION
## Summary
- add a toggle to switch between a single prompt and a structured message list for chat completion
- update the chat completion executor to send role-aware message arrays and validate input
- document the new configuration in the README

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ecd69916ac832996ec376f7b169cb6